### PR TITLE
ciにlighthouseを追加

### DIFF
--- a/.github/workflows/lighthouse.json
+++ b/.github/workflows/lighthouse.json
@@ -1,0 +1,10 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "total-blocking-time": ["error", {"maxNumericValue": 1000}],
+        "interactive": ["error", {"maxNumericValue": 4000}]
+      }
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,16 @@
+
+name: Measure Web Performance
+on:
+  schedule:
+    - cron: '0 1,5,9,13,17,21 * * *'
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Audit URL using lighthouse
+        uses: treosh/lighthouse-ci-action@v3
+        with:
+          urls: https://www.shuwasystem.co.jp/smp/
+          configPath: ./.github/workflows/lighthouserc.json
+          uploadArtifacts: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,3 @@ jobs:
     - uses: c-hive/gha-yarn-cache@v1
     - name: Package Install
       run: yarn
-    # - name: TypeScript Compile
-    #   run: yarn lint:ts


### PR DESCRIPTION
---
name: pull-request template
about: プルリク作成時のテンプレート
title: ''
labels: ''
assignees: ''

---

## 背景・目的
パフォーマンス計測の自動化。
閾値を超えた場合エラーを返すようにCIを設定。

## やったこと
- lighthouseをgithub-workflowに追加

## 確認して欲しいこと

## 参考
https://medium.com/@yonemoto/lighthouse-ci%E3%82%92%E5%88%A9%E7%94%A8%E3%81%97%E3%81%9Fweb%E3%82%B5%E3%82%A4%E3%83%88%E5%93%81%E8%B3%AA%E7%9B%A3%E6%9F%BB%E3%81%AE%E8%87%AA%E5%8B%95%E5%8C%96-9f1b3b431c54

https://github.com/n05-frontend/shuwa-frontend-book-app/tree/chapter_7-2

### URL
### スクリーンショット
